### PR TITLE
AMA-1232: Added improved handling of LTI URL and CustomParameters.

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -123,11 +123,7 @@ APP = {
   # Opencast
   'opencast': {
       'base_url' : 'https://media.uct.ac.za',
-      'content_item_path' : '/lti/player/',
-      'match' : {
-        'media.uct.ac.za': 'https://media.uct.ac.za/lti',
-        'mediadev.uct.ac.za': 'https://mediadev.uct.ac.za/lti'
-      }
+      'content_item_path' : '/lti/player/'
   },
 
   # Local middleware
@@ -258,9 +254,17 @@ APP = {
   # Map content item URLs to tool providers
   # This enables updating ACLs in third party systems based on URLs used in LTI quicklinks
   'lti': {
-          'content_item_urls': {
-              'https://media.uct.ac.za/lti/player/' : 'opencast'
+      'content_item_urls': {
+          'https://media.uct.ac.za/lti/player/' : 'opencast'
+      },
+      'match' : {
+          'https://media.uct.ac.za/lti' : {
+              'url': 'https://media.uct.ac.za/lti/player/', 'valid': ['tool']
+          },
+          'https://mediadev.uct.ac.za/lti' : {
+              'url': 'https://mediadev.uct.ac.za/lti/player/', 'valid': ['tool']
           }
+      }
   },
 
   'path': Path().absolute(),

--- a/config/config.py
+++ b/config/config.py
@@ -123,7 +123,11 @@ APP = {
   # Opencast
   'opencast': {
       'base_url' : 'https://media.uct.ac.za',
-      'content_item_path' : '/lti/player/'
+      'content_item_path' : '/lti/player/',
+      'match' : {
+        'media.uct.ac.za': 'https://media.uct.ac.za/lti',
+        'mediadev.uct.ac.za': 'https://mediadev.uct.ac.za/lti'
+      }
   },
 
   # Local middleware

--- a/work/check_for_placeholders.py
+++ b/work/check_for_placeholders.py
@@ -176,9 +176,11 @@ def get_topic_id(content_toc, topic_path):
 
     return topic_id
 
+# take {'tool': '/play/[MPID]'} > [{'Name':'tool', 'Value':'/play/[MPID]'}]
 def dict_to_name_value_array(input_dict):
     return [{'Name': key, 'Value': value} for key, value in input_dict.items()]
 
+# take "tool=/play/[MPID]" > [{'Name':'tool', 'Value':'/play/[MPID]'}]
 def construct_CustomParameters(input_string):
     result = []
     lines = input_string.strip().splitlines()
@@ -192,15 +194,26 @@ def construct_CustomParameters(input_string):
 
     return result
 
-def set_quicklink_url(cfg, base_url, parms):
+# If the base_url for the LTI tool is a "[opencast]/lti" link and it refers to a "play" tool
+# then return unique URL with the [domain][content_item_path][event_id] - which will play correctly
+def get_quicklink_url(cfg, base_url, parms):
+    if base_url not in cfg['lti']['match']:
+        return base_url
+
     for entry in parms:
         if entry['Name'] == 'tool' and entry['Value'].startswith('/play/'):
             event_id = entry['Value'].split('/play/', 1)[1]
-            for domain, url in cfg['opencast']['match'].items():
-                if url == base_url:
-                    return f"https://{domain}{cfg['opencast']['content_item_path']}{event_id}"
+            return f"{cfg['lti']['match'][base_url]['url']}{event_id}"
+
     return base_url
 
+def filter_name_value_array(cfg, base_url, parms):
+    if base_url in cfg['lti']['match']:
+        if not cfg['lti']['match'][base_url]['valid']:
+            return parms
+        return [entry for entry in parms if entry['Name'] in cfg['lti']['match'][base_url]['valid']]
+
+    return parms
 
 def run(SITE_ID, APP, import_id, transfer_id):
 
@@ -392,6 +405,9 @@ def run(SITE_ID, APP, import_id, transfer_id):
                     tool = None
 
                     if content_item:
+                        # use the content item json object
+                        # if it contains LTI tool custom parameter configurations
+                        #     then construct a "Name", "Value" dictionary object as required by D2L
                         content_json = json.loads(content_item)
                         if '@graph' in content_json and len(content_json['@graph']) > 0:
                             ci_0 = content_json['@graph'][0]
@@ -401,7 +417,9 @@ def run(SITE_ID, APP, import_id, transfer_id):
                             if 'custom' in content_json:
                                 tool = dict_to_name_value_array(content_json['custom'])
 
-                    # https://docs.valence.desire2learn.com/res/lti.html#LTI.CreateLtiLinkData
+                    # Construct LTI custom parameter from the sakai link data
+                    # return a "Name", "Value" dictionary object required by:
+                    #     https://docs.valence.desire2learn.com/res/lti.html#LTI.CreateLtiLinkData
                     if tool is None:
                         tool = construct_CustomParameters(sakai_link_data['custom'])
 
@@ -410,12 +428,17 @@ def run(SITE_ID, APP, import_id, transfer_id):
                         tool = None
 
                     lti_link_data = {
-                            "Url" : set_quicklink_url(APP, sakai_link_data['launch'], tool),
+                            # Get unique Url if LTI match and "play" tool link
+                            "Url" : get_quicklink_url(APP, sakai_link_data['launch'], tool),
                             "Title" : sakai_link_data['title'],
                             "Description" : sakai_link_data['description'],
-                            "CustomParameters": tool
+                            # filter unwanted parameters if LTI match
+                            "CustomParameters": filter_name_value_array(APP, sakai_link_data['launch'], tool)
                     }
 
+                    # Create a new QuickLink - the "Url" is used as a unique value
+                    # if the Url exists - don't create a new link
+                    # - in this case the unique Url is constructed with "set_quicklink_url"
                     quicklink_url = create_lti_quicklink(APP, import_id, lti_link_data)
                     logging.info(f"Quicklink for {lti_link_data['Url']} is {quicklink_url}")
 


### PR DESCRIPTION
Improved the handling of the LTI URL by adding in a check to see if it is an Opencast link which then gets changed so that it includes the 'content_item_path'. The test url ('match') is configurable in `config/config.py`.

Additionally the CustomParameters handling has been improved so that it constructs a dictionary based on _all_ the custom parameters as defined in the placeholder config for that element. 