### PR TITLE
Fix for Unreachable code

### DIFF
--- a/lib/ffprobe_uct.py
+++ b/lib/ffprobe_uct.py
@@ -111,10 +111,6 @@ class FFProbe_UCT:
                     side_data = False
                     continue
 
-                if (side_data):
-                    continue
-                    #Skip Side data tags
-
                 if '[STREAM]' in line:
                     stream = True
                     data_lines = []


### PR DESCRIPTION
In general, fix unreachable code by removing or restructuring duplicated control-flow branches so each reachable path is meaningful.

Best fix here: remove the second redundant `if (side_data): continue` block (lines 114–116 area) and keep the earlier one. This preserves behavior because all `side_data == True` iterations are already skipped before reaching stream parsing. No import or new method is needed; this is a small control-flow cleanup in `lib/ffprobe_uct.py` within the loop reading `p.stderr`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._