### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,7 @@ class QueryTestCase(unittest.TestCase):
         with open(APP['report']['json']) as json_file:
             conf=json.load(json_file)
             self.assertGreater(len(conf['issues']), 0)
-            self.assertTrue(len(conf['tools']) > 0)
+            self.assertGreater(len(conf['tools']), 0)
 
         with open(APP['lessons']['styles']) as json_file:
             conf = json.load(json_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,7 +35,7 @@ class QueryTestCase(unittest.TestCase):
         # JSON Configs
         with open(APP['report']['json']) as json_file:
             conf=json.load(json_file)
-            self.assertTrue(len(conf['issues']) > 0)
+            self.assertGreater(len(conf['issues']), 0)
             self.assertTrue(len(conf['tools']) > 0)
 
         with open(APP['lessons']['styles']) as json_file:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,7 @@ class QueryTestCase(unittest.TestCase):
         self.assertGreater(len(mime_types['FILES']), 0)
 
         restricted_ext = lib.utils.read_yaml(APP['content']['restricted-ext'])
-        self.assertTrue(len(restricted_ext['RESTRICTED_EXT']) > 0)
+        self.assertGreater(len(restricted_ext['RESTRICTED_EXT']), 0)
 
         # JSON Configs
         with open(APP['report']['json']) as json_file:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ class QueryTestCase(unittest.TestCase):
 
         # Other YAML
         mime_types = lib.utils.read_yaml(APP['content']['mime-types'])
-        self.assertTrue(len(mime_types['FILES']) > 0)
+        self.assertGreater(len(mime_types['FILES']), 0)
 
         restricted_ext = lib.utils.read_yaml(APP['content']['restricted-ext'])
         self.assertTrue(len(restricted_ext['RESTRICTED_EXT']) > 0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,7 @@ class QueryTestCase(unittest.TestCase):
 
         with open(APP['lessons']['styles']) as json_file:
             conf = json.load(json_file)
-            self.assertTrue(len(conf['general']['tags.to.search']) > 0)
+            self.assertGreater(len(conf['general']['tags.to.search']), 0)
 
     # Test the email templates for valid syntax
     def test_template_syntax(self):

--- a/tests/test_generate_conversion_report.py
+++ b/tests/test_generate_conversion_report.py
@@ -52,7 +52,7 @@ class GenerateConversionReportTestCase(unittest.TestCase):
     def test_main_no_issue_key(self, mock_log, mock_check, *_):
         main()
         self.assertTrue(mock_check.called)
-        self.assertTrue(mock_check.call_count>1)
+        self.assertGreater(mock_check.call_count, 1)
         self.assertFalse(mock_log.called)
         self.assertEqual(0, mock_log.call_count)
 


### PR DESCRIPTION
Use a specific unittest assertion for numeric comparison instead of a boolean-wrapped comparison.

Best fix: in `tests/test_config.py`, replace the flagged line in `test_config`:
- From `self.assertTrue(len(conf['issues']) > 0)`
- To `self.assertGreater(len(conf['issues']), 0)`

This keeps functionality unchanged (still requires at least one issue) and provides clearer failure messages that include both operands. No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._