### PR TITLE
Fix for Use of exit() or quit()

### DIFF
--- a/utils/pushDataSource.py
+++ b/utils/pushDataSource.py
@@ -75,11 +75,11 @@ def main():
 
     if not csv_file or not ds_id:
         logging.error("Must specify both CSV and ID")
-        exit(1)
+        sys.exit(1)
 
     if not os.path.exists(csv_file):
         logging.error(f"CSV file {csv_file} not found")
-        exit(1)
+        sys.exit(1)
 
     PDS.PushCSV(ds_id, csv_file)
 


### PR DESCRIPTION
Use `sys.exit(1)` instead of `exit(1)` for process termination in scripts.

Best fix here: in `utils/pushDataSource.py`, replace both `exit(1)` calls (the missing-args branch and missing-file branch) with `sys.exit(1)`. No new imports are needed because `sys` is already imported at line 8. This preserves functionality (same non-zero exit code and flow) while removing dependency on `site` internals.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._