### PR TITLE
Fix for Module is imported more than once

### DIFF
--- a/work/content_sort_units.py
+++ b/work/content_sort_units.py
@@ -13,7 +13,6 @@ sys.path.append(parent)
 
 import config.config
 import config.logging_config
-import lib.db
 from lib.d2l import middleware_api
 
 def run(SITE_ID, LINK_ID, APP):


### PR DESCRIPTION
To fix this, remove the second `import lib.db` (line 16) and keep the first one (line 6).  
This is the best fix because it eliminates the redundancy with zero functional impact, preserves existing usage (`lib.db.MigrationDb(APP)`), and does not require any additional refactoring.

In `work/content_sort_units.py`, edit the import block around lines 14–17:
- Keep:
  - `import config.config`
  - `import config.logging_config`
  - `from lib.d2l import middleware_api`
- Delete only the duplicate `import lib.db`.

No new methods, definitions, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._