### PR TITLE
Fix for Empty except

### DIFF
--- a/lib/jira_rest.py
+++ b/lib/jira_rest.py
@@ -28,7 +28,7 @@ def create_jira(APP, url, site_id, site_title, jira_state, jira_log, failure_typ
             N = APP['jira']['last']
             jira_log = jira_log[-N:]
     except (TypeError, ValueError):
-        pass
+        logging.debug("jira_log is not valid JSON/list input; using raw jira_log value")
 
     if isinstance(jira_log, list):
         jira_log_str = "\n".join(jira_log)


### PR DESCRIPTION
Keep existing functionality (fallback to original `jira_log` when JSON parse fails), but replace the empty `except` body with a debug log message explaining that non-JSON/invalid JSON is expected and the raw value will be used.

Best single fix in `lib/jira_rest.py`:
- In `create_jira(...)`, update the `except (TypeError, ValueError):` block (around lines 30–31).
- Replace `pass` with a `logging.debug(...)` call that documents the intentional fallback behavior.
- No imports or new dependencies are needed (the file already imports `logging`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._